### PR TITLE
[codex] Clean up app behavior

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,6 +1,4 @@
 import 'dart:convert';
-import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
@@ -32,9 +30,12 @@ Future<void> setUserStartDateIfMissing(String userId) async {
     final user = await pb.collection('users').getOne(userId);
     if (user.data['startDate'] == null ||
         user.data['startDate'].toString().isEmpty) {
-      await pb.collection('users').update(userId, body: {
-        'startDate': DateTime.now().toIso8601String(),
-      });
+      await pb
+          .collection('users')
+          .update(
+            userId,
+            body: {'startDate': DateTime.now().toIso8601String()},
+          );
     }
   } catch (e) {
     throw Exception('Error setting user start date: $e');
@@ -71,68 +72,33 @@ Future<bool> uploadData(String userId, Map<String, dynamic> usageData) async {
 /// Creates a new record in the `ios_screentime` collection with the given
 /// image file and links it to the provided [userId].
 ///
-/// Provide either [imageBytes] or [filePath]. Returns the created record id
-/// on success, or `null` on failure.
+/// Returns the created record id on success, or `null` on failure.
 Future<String?> saveIosScreenTime({
   required String userId,
-  Uint8List? imageBytes,
-  String? filePath,
+  required Uint8List imageBytes,
   String fileName = 'screentime.png',
 }) async {
   try {
     final files = <http.MultipartFile>[];
 
-    MediaType? contentType;
-
-    if (imageBytes != null) {
-      contentType = _resolveMediaType(fileName, imageBytes);
-      files.add(
-        http.MultipartFile.fromBytes(
-          'image',
-          imageBytes,
-          filename: fileName,
-          contentType: contentType,
-        ),
-      );
-    } else if (filePath != null) {
-      contentType = _resolveMediaType(fileName, await _peekFileBytes(filePath));
-      files.add(
-        await http.MultipartFile.fromPath(
-          'image',
-          filePath,
-          filename: fileName,
-          contentType: contentType,
-        ),
-      );
-    } else {
-      throw ArgumentError('Either imageBytes or filePath must be provided');
-    }
-
-    final record = await pb.collection('ios_screentime').create(
-      body: {
-        'user': userId,
-      },
-      files: files,
+    final contentType = _resolveMediaType(fileName, imageBytes);
+    files.add(
+      http.MultipartFile.fromBytes(
+        'image',
+        imageBytes,
+        filename: fileName,
+        contentType: contentType,
+      ),
     );
+
+    final record = await pb
+        .collection('ios_screentime')
+        .create(body: {'user': userId}, files: files);
 
     return record.id;
   } catch (e) {
     // Return a descriptive error via null; caller should show a message
     print('Error saving ios_screentime for user $userId: $e');
-    return null;
-  }
-}
-
-Future<Uint8List?> _peekFileBytes(String path, {int maxLength = 16}) async {
-  try {
-    final file = File(path);
-    if (!await file.exists()) return null;
-    final bytes = await file.openRead(0, maxLength).fold<BytesBuilder>(
-          BytesBuilder(),
-          (builder, data) => builder..add(data),
-        );
-    return bytes.takeBytes();
-  } catch (_) {
     return null;
   }
 }
@@ -148,8 +114,11 @@ MediaType? _resolveMediaType(String fileName, Uint8List? headerBytes) {
 }
 
 Future<bool> answerQuestionnaire(
-    String userId, String questionnaireId, Map<String, dynamic> answers,
-    {DateTime? customDate}) async {
+  String userId,
+  String questionnaireId,
+  Map<String, dynamic> answers, {
+  DateTime? customDate,
+}) async {
   try {
     final body = {
       'user': userId,
@@ -170,7 +139,9 @@ Future<bool> answerQuestionnaire(
 
 Future<List<Map<String, dynamic>>> fetchUserAnswers(String userId) async {
   try {
-    final result = await pb.collection('answers').getFullList(
+    final result = await pb
+        .collection('answers')
+        .getFullList(
           filter: "user = '$userId'",
           sort: '-created',
           expand: 'questionnaire',
@@ -182,14 +153,9 @@ Future<List<Map<String, dynamic>>> fetchUserAnswers(String userId) async {
   }
 }
 
-Future<bool> editAnswer(
-  String answerId,
-  Map<String, dynamic> answers,
-) async {
+Future<bool> editAnswer(String answerId, Map<String, dynamic> answers) async {
   try {
-    await pb.collection('answers').update(answerId, body: {
-      'data': answers,
-    });
+    await pb.collection('answers').update(answerId, body: {'data': answers});
     return true;
   } catch (e) {
     throw Exception('Error answering questionnaire: $e');
@@ -197,9 +163,12 @@ Future<bool> editAnswer(
 }
 
 Future<List<Questionnaire>> fetchQuestionnaires() async {
-  final result = await pb.collection('questionnaires').getFullList(
+  final result = await pb
+      .collection('questionnaires')
+      .getFullList(
         sort: '-created',
-        expand: 'questions,'
+        expand:
+            'questions,'
             'questions.options,'
             'questions.subQuestions,'
             'questions.subQuestions.options,'
@@ -216,9 +185,12 @@ Future<List<Questionnaire>> fetchQuestionnaires() async {
 
 Future<Questionnaire> fetchQuestionnaireById(String questionnaireId) async {
   try {
-    final record = await pb.collection('questionnaires').getOne(
+    final record = await pb
+        .collection('questionnaires')
+        .getOne(
           questionnaireId,
-          expand: 'questions,'
+          expand:
+              'questions,'
               'questions.options,'
               'questions.subQuestions,'
               'questions.subQuestions.options,'
@@ -277,8 +249,9 @@ class Question {
     final expand = json['expand'] as Map<String, dynamic>? ?? {};
 
     final optionsData = expand['options'] as List<dynamic>? ?? [];
-    final options =
-        optionsData.map((data) => AnswerOption.fromJson(data)).toList();
+    final options = optionsData
+        .map((data) => AnswerOption.fromJson(data))
+        .toList();
 
     options.sort((a, b) {
       if (a.valueNumber != null && b.valueNumber != null) {
@@ -290,8 +263,9 @@ class Question {
     });
 
     final subQuestionsData = expand['subQuestions'] as List<dynamic>? ?? [];
-    final subQuestions =
-        subQuestionsData.map((data) => Question.fromJson(data)).toList();
+    final subQuestions = subQuestionsData
+        .map((data) => Question.fromJson(data))
+        .toList();
 
     subQuestions.sort((a, b) => _alphanumericCompare(a.name, b.name));
 
@@ -300,8 +274,9 @@ class Question {
       name: json['name'] ?? '',
       text: json['text'] ?? '',
       type: json['type'] ?? 'freeText',
-      showWhenParentIs:
-          json['showWhenParentIs'] == '' ? null : json['showWhenParentIs'],
+      showWhenParentIs: json['showWhenParentIs'] == ''
+          ? null
+          : json['showWhenParentIs'],
       options: options,
       subQuestions: subQuestions,
     );
@@ -309,13 +284,16 @@ class Question {
 }
 
 int _alphanumericCompare(String a, String b) {
-  final aMatches =
-      RegExp(r'(\d+|\D+)').allMatches(a).map((m) => m.group(0)!).toList();
-  final bMatches =
-      RegExp(r'(\d+|\D+)').allMatches(b).map((m) => m.group(0)!).toList();
+  final aMatches = RegExp(
+    r'(\d+|\D+)',
+  ).allMatches(a).map((m) => m.group(0)!).toList();
+  final bMatches = RegExp(
+    r'(\d+|\D+)',
+  ).allMatches(b).map((m) => m.group(0)!).toList();
 
-  final maxLength =
-      aMatches.length > bMatches.length ? aMatches.length : bMatches.length;
+  final maxLength = aMatches.length > bMatches.length
+      ? aMatches.length
+      : bMatches.length;
 
   for (int i = 0; i < maxLength; i++) {
     if (i >= aMatches.length) return -1;
@@ -354,8 +332,9 @@ class Questionnaire {
     final expand = json['expand'] as Map<String, dynamic>? ?? {};
     final questionsData = expand['questions'] as List<dynamic>? ?? [];
 
-    final allQuestions =
-        questionsData.map((q) => Question.fromJson(q)).toList();
+    final allQuestions = questionsData
+        .map((q) => Question.fromJson(q))
+        .toList();
 
     final Set<String> subQuestionIds = {};
     void collectSubQuestionIds(List<Question> questions) {
@@ -372,8 +351,9 @@ class Questionnaire {
 
     collectSubQuestionIds(allQuestions);
 
-    final topLevelQuestions =
-        allQuestions.where((q) => !subQuestionIds.contains(q.id)).toList();
+    final topLevelQuestions = allQuestions
+        .where((q) => !subQuestionIds.contains(q.id))
+        .toList();
 
     topLevelQuestions.sort((a, b) {
       return _alphanumericCompare(a.name, b.name);
@@ -386,5 +366,3 @@ class Questionnaire {
     );
   }
 }
-
-

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:screen_time/router.dart';
 import 'package:screen_time/theme/app_theme.dart';
@@ -20,16 +20,21 @@ class MyApp extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final lifecycleObserver = useMemoized(() => _AppLifecycleObserver(ref), [
+      ref,
+    ]);
+
+    useEffect(() {
+      WidgetsBinding.instance.addObserver(lifecycleObserver);
+      return () {
+        WidgetsBinding.instance.removeObserver(lifecycleObserver);
+      };
+    }, [lifecycleObserver]);
+
     final userState = ref.watch(userIdProvider);
     final router = ref.watch(
-      routerProvider(
-        RouterProps(
-          loggedIn: userState.userId != null,
-        ),
-      ),
+      routerProvider(RouterProps(loggedIn: userState.userId != null)),
     );
-
-    WidgetsBinding.instance.addObserver(_AppLifecycleObserver(ref));
 
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,

--- a/lib/providers/usage_provider.dart
+++ b/lib/providers/usage_provider.dart
@@ -1,14 +1,14 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'package:flutter/services.dart';
 import 'package:screen_time/api.dart' as api;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:screentime/screentime.dart';
+import 'package:screen_time/utils/platform_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'dart:io';
 
-final usageProvider =
-    StateNotifierProvider<UsageNotifier, UsageState>((ref) => UsageNotifier());
+final usageProvider = StateNotifierProvider<UsageNotifier, UsageState>(
+  (ref) => UsageNotifier(),
+);
 
 class UsageState {
   final String date;
@@ -38,14 +38,23 @@ class UsageState {
 
 class UsageNotifier extends StateNotifier<UsageState> {
   // Spara dagens skärmtid till localstorage
-  Future<void> saveTodayUsageToLocal() async {
+  Future<void> saveUsageToLocal({
+    String? date,
+    Map<String, int>? usageData,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    final date = state.date;
-    final usage = state.usageData;
+    final usageDate = date ?? state.date;
+    final usage = usageData ?? state.usageData;
     final raw = prefs.getString('screenTimeLocal') ?? '{}';
     final Map<String, dynamic> allData = jsonDecode(raw);
-    allData[date] = usage.map((key, value) {
-      final storedValue = allData[date]?[key] ?? 0;
+    final existingForDate = allData[usageDate] is Map
+        ? Map<String, dynamic>.from(allData[usageDate] as Map)
+        : <String, dynamic>{};
+
+    allData[usageDate] = usage.map((key, value) {
+      final storedValue = existingForDate[key] is int
+          ? existingForDate[key] as int
+          : int.tryParse(existingForDate[key]?.toString() ?? '') ?? 0;
       final highestValue = storedValue > value ? storedValue : value;
 
       return MapEntry(key, highestValue);
@@ -53,13 +62,16 @@ class UsageNotifier extends StateNotifier<UsageState> {
     await prefs.setString('screenTimeLocal', jsonEncode(allData));
   }
 
+  Future<void> saveTodayUsageToLocal() => saveUsageToLocal();
+
   // Hämta all sparad skärmtid från localstorage
   Future<Map<String, Map<String, int>>> getAllLocalUsage() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString('screenTimeLocal') ?? '{}';
     final Map<String, dynamic> allData = jsonDecode(raw);
-    return allData
-        .map((date, usage) => MapEntry(date, Map<String, int>.from(usage)));
+    return allData.map(
+      (date, usage) => MapEntry(date, Map<String, int>.from(usage)),
+    );
   }
 
   // Rensa all sparad skärmtid från localstorage
@@ -68,19 +80,24 @@ class UsageNotifier extends StateNotifier<UsageState> {
     await prefs.remove('screenTimeLocal');
   }
 
-  bool get isAndroid => Platform.isAndroid;
+  bool get isAndroid => PlatformUtils.isAndroid;
   DateTime lastUpdate = DateTime(1900, 1, 1);
+  late final Future<void> _lastUpdateLoaded;
 
   UsageNotifier()
-      : super(UsageState(
+    : super(
+        UsageState(
           date: _currentDate(),
           usageData: {},
-          hasPermission: Platform.isAndroid,
-          isLoading: Platform.isAndroid,
-        )) {
-    if (Platform.isAndroid) {
+          hasPermission: PlatformUtils.isAndroid,
+          isLoading: PlatformUtils.isAndroid,
+        ),
+      ) {
+    if (PlatformUtils.isAndroid) {
+      _lastUpdateLoaded = _loadLastUpdate();
       checkUsageStatsPermission();
-      _loadLastUpdate();
+    } else {
+      _lastUpdateLoaded = Future.value();
     }
   }
 
@@ -109,15 +126,18 @@ class UsageNotifier extends StateNotifier<UsageState> {
 
   Future<void> checkUsageStatsPermission() async {
     if (!isAndroid) {
-      state =
-          state.copyWith(hasPermission: false, isLoading: false, usageData: {});
+      state = state.copyWith(
+        hasPermission: false,
+        isLoading: false,
+        usageData: {},
+      );
       return;
     }
     try {
       final bool permitted = await Screentime().hasPermission();
       state = state.copyWith(hasPermission: permitted, isLoading: false);
       if (permitted) {
-        getUsageStats();
+        await getUsageStats();
       }
     } on PlatformException catch (e) {
       print("checkUsageStatsPermission error: [31m${e.message}[0m");
@@ -134,7 +154,7 @@ class UsageNotifier extends StateNotifier<UsageState> {
       final bool permitted = await Screentime().hasPermission();
       state = state.copyWith(hasPermission: permitted);
       if (permitted) {
-        getUsageStats();
+        await getUsageStats();
       }
     } on PlatformException catch (e) {
       print("requestUsageStatsPermission error: ${e.message}");
@@ -159,10 +179,11 @@ class UsageNotifier extends StateNotifier<UsageState> {
         final dateStr =
             "${day.year}-${day.month.toString().padLeft(2, '0')}-${day.day.toString().padLeft(2, '0')}";
         try {
-          final Map<String, int> result =
-              await Screentime().getUsageStats(dateStr);
+          final Map<String, int> result = await Screentime().getUsageStats(
+            dateStr,
+          );
           state = state.copyWith(date: dateStr, usageData: result);
-          await saveTodayUsageToLocal();
+          await saveUsageToLocal(date: dateStr, usageData: result);
 
           if (dateStr == date) {
             usage = result;
@@ -180,7 +201,7 @@ class UsageNotifier extends StateNotifier<UsageState> {
 
   Future<void> updateDate(String newDate) async {
     state = state.copyWith(date: newDate);
-    getUsageStats();
+    await getUsageStats();
   }
 
   Future<bool> uploadData(String userId) async {
@@ -195,27 +216,21 @@ class UsageNotifier extends StateNotifier<UsageState> {
       );
       print("uploadData.after Screentime.getUsageStats: $entries");
 
-      await saveTodayUsageToLocal();
+      await saveUsageToLocal(date: state.date, usageData: entries);
 
       final List<Map<String, dynamic>> entriesList = [];
       entries.forEach((key, value) {
-        entriesList.add({
-          'date': state.date,
-          'hour': key,
-          'seconds': value,
-        });
+        entriesList.add({'date': state.date, 'hour': key, 'seconds': value});
       });
 
-      final Map<String, dynamic> result = {
-        'screenTimeEntries': entriesList,
-      };
+      final Map<String, dynamic> result = {'screenTimeEntries': entriesList};
 
       print("before api.uploadData: $result");
 
       bool success = await api.uploadData(userId, result);
 
       if (success) {
-        _saveLastUpdate();
+        await _saveLastUpdate();
         return true;
       }
     } on PlatformException catch (_) {}
@@ -224,13 +239,19 @@ class UsageNotifier extends StateNotifier<UsageState> {
   }
 
   Future<void> autoUploadIfNeeded(String userId) async {
+    await _lastUpdateLoaded;
+
     final now = DateTime.now();
     final timeSinceLastUpdate = now.difference(lastUpdate);
 
     if (timeSinceLastUpdate.inMinutes > 30) {
       try {
-        await uploadData(userId);
-        print('Auto-upload completed at ${now.toIso8601String()}');
+        final uploaded = await uploadData(userId);
+        if (uploaded) {
+          print('Auto-upload completed at ${now.toIso8601String()}');
+        } else {
+          print('Auto-upload skipped or failed at ${now.toIso8601String()}');
+        }
       } catch (e) {
         print('Auto-upload failed: $e');
       }
@@ -247,20 +268,14 @@ class UsageNotifier extends StateNotifier<UsageState> {
       final List<Map<String, dynamic>> entriesList = [];
       allData.forEach((date, usage) {
         usage.forEach((hour, seconds) {
-          entriesList.add({
-            'date': date,
-            'hour': hour,
-            'seconds': seconds,
-          });
+          entriesList.add({'date': date, 'hour': hour, 'seconds': seconds});
         });
       });
-      final Map<String, dynamic> result = {
-        'screenTimeEntries': entriesList,
-      };
+      final Map<String, dynamic> result = {'screenTimeEntries': entriesList};
       bool success = await api.uploadData(userId, result);
       if (success) {
         await clearLocalUsage();
-        _saveLastUpdate();
+        await _saveLastUpdate();
         return true;
       }
     } catch (e) {

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'usage_provider.dart';
 

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -7,20 +7,14 @@ import 'package:screen_time/screens/Login.dart';
 import 'package:screen_time/screens/Usage.dart';
 import 'package:screen_time/screens/Splash.dart';
 import 'package:screen_time/providers/usage_provider.dart';
-import 'dart:io';
+import 'package:screen_time/utils/platform_utils.dart';
 
 class RouterNotifier extends ChangeNotifier {
   final Ref _ref;
 
   RouterNotifier(this._ref) {
-    _ref.listen<UserState>(
-      userIdProvider,
-      (_, __) => notifyListeners(),
-    );
-    _ref.listen<UsageState>(
-      usageProvider,
-      (_, __) => notifyListeners(),
-    );
+    _ref.listen<UserState>(userIdProvider, (_, __) => notifyListeners());
+    _ref.listen<UsageState>(usageProvider, (_, __) => notifyListeners());
   }
 
   String? _redirectLogic(BuildContext context, GoRouterState state) {
@@ -32,7 +26,7 @@ class RouterNotifier extends ChangeNotifier {
       return '/splash';
     }
 
-    if (!Platform.isAndroid) {
+    if (!PlatformUtils.isAndroid) {
       if (userState.userId == null && state.uri.toString() != '/login') {
         return '/login';
       }

--- a/lib/screens/ScreentimeView.dart
+++ b/lib/screens/ScreentimeView.dart
@@ -5,7 +5,7 @@ import 'package:screen_time/providers/user_provider.dart';
 import 'package:screen_time/theme/app_theme.dart';
 import 'package:screen_time/widgets/total_usage_text.dart';
 import 'package:screen_time/utils/network_utils.dart';
-import 'dart:io';
+import 'package:screen_time/utils/platform_utils.dart';
 
 class ScreentimeViewPage extends ConsumerWidget {
   const ScreentimeViewPage({super.key});
@@ -24,7 +24,7 @@ class ScreentimeViewPage extends ConsumerWidget {
       'september',
       'oktober',
       'november',
-      'december'
+      'december',
     ];
     return '${date.day} ${months[date.month - 1]} ${date.year}';
   }
@@ -38,7 +38,7 @@ class ScreentimeViewPage extends ConsumerWidget {
       'torsdag',
       'fredag',
       'lördag',
-      'söndag'
+      'söndag',
     ];
     return weekdays[date.weekday - 1];
   }
@@ -130,9 +130,11 @@ class ScreentimeViewPage extends ConsumerWidget {
     } catch (e) {
       if (context.mounted) {
         final isNetworkError = NetworkUtils.isNetworkError(e);
-        final errorMessage = NetworkUtils.getErrorMessage(e,
-            customNetworkMessage:
-                'Internetanslutningen bröts under uppladdningen. Kontrollera din anslutning och försök igen.');
+        final errorMessage = NetworkUtils.getErrorMessage(
+          e,
+          customNetworkMessage:
+              'Internetanslutningen bröts under uppladdningen. Kontrollera din anslutning och försök igen.',
+        );
 
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -173,7 +175,7 @@ class ScreentimeViewPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!Platform.isAndroid) {
+    if (!PlatformUtils.isAndroid) {
       return Scaffold(
         backgroundColor: AppTheme.background,
         appBar: AppBar(
@@ -193,10 +195,7 @@ class ScreentimeViewPage extends ConsumerWidget {
         body: const Center(
           child: Text(
             'Skärmtidsdata är endast tillgänglig på Android',
-            style: TextStyle(
-              fontSize: 16,
-              color: AppTheme.primary,
-            ),
+            style: TextStyle(fontSize: 16, color: AppTheme.primary),
             textAlign: TextAlign.center,
           ),
         ),
@@ -256,7 +255,9 @@ class ScreentimeViewPage extends ConsumerWidget {
                       if (isToday) ...[
                         Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 4),
+                            horizontal: 12,
+                            vertical: 4,
+                          ),
                           decoration: BoxDecoration(
                             color: AppTheme.primary,
                             borderRadius: BorderRadius.circular(12),
@@ -275,15 +276,15 @@ class ScreentimeViewPage extends ConsumerWidget {
                       Text(
                         _formatDate(usageState.date),
                         style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              color: AppTheme.primary,
-                            ),
+                          fontWeight: FontWeight.w600,
+                          color: AppTheme.primary,
+                        ),
                       ),
                       Text(
                         _getWeekday(usageState.date),
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              color: AppTheme.primary.withValues(alpha: 0.7),
-                            ),
+                          color: AppTheme.primary.withValues(alpha: 0.7),
+                        ),
                       ),
                     ],
                   ),
@@ -308,7 +309,8 @@ class ScreentimeViewPage extends ConsumerWidget {
                         Card(
                           elevation: 2,
                           shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(16)),
+                            borderRadius: BorderRadius.circular(16),
+                          ),
                           child: Container(
                             width: double.infinity,
                             padding: const EdgeInsets.all(24.0),
@@ -317,22 +319,23 @@ class ScreentimeViewPage extends ConsumerWidget {
                                 Icon(
                                   Icons.phone_android,
                                   size: 48,
-                                  color:
-                                      AppTheme.primary.withValues(alpha: 0.7),
+                                  color: AppTheme.primary.withValues(
+                                    alpha: 0.7,
+                                  ),
                                 ),
                                 const SizedBox(height: 16),
                                 if (totalSeconds > 0) ...[
                                   TotalUsageText(
-                                      totalMins: totalSeconds / 60.0),
+                                    totalMins: totalSeconds / 60.0,
+                                  ),
                                   const SizedBox(height: 8),
                                   Text(
                                     'Total skärmtid',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyLarge
+                                    style: Theme.of(context).textTheme.bodyLarge
                                         ?.copyWith(
-                                          color: AppTheme.primary
-                                              .withValues(alpha: 0.7),
+                                          color: AppTheme.primary.withValues(
+                                            alpha: 0.7,
+                                          ),
                                         ),
                                   ),
                                 ] else ...[
@@ -349,12 +352,11 @@ class ScreentimeViewPage extends ConsumerWidget {
                                   const SizedBox(height: 8),
                                   Text(
                                     'Ingen skärmtid registrerad',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyLarge
+                                    style: Theme.of(context).textTheme.bodyLarge
                                         ?.copyWith(
-                                          color: AppTheme.primary
-                                              .withValues(alpha: 0.7),
+                                          color: AppTheme.primary.withValues(
+                                            alpha: 0.7,
+                                          ),
                                         ),
                                   ),
                                 ],
@@ -396,7 +398,11 @@ class ScreentimeViewPage extends ConsumerWidget {
   }
 
   Widget _buildStatCard(
-      BuildContext context, String label, String value, IconData icon) {
+    BuildContext context,
+    String label,
+    String value,
+    IconData icon,
+  ) {
     return Card(
       elevation: 1,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
@@ -404,22 +410,25 @@ class ScreentimeViewPage extends ConsumerWidget {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
-            Icon(icon,
-                color: AppTheme.primary.withValues(alpha: 0.7), size: 24),
+            Icon(
+              icon,
+              color: AppTheme.primary.withValues(alpha: 0.7),
+              size: 24,
+            ),
             const SizedBox(height: 8),
             Text(
               value,
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: AppTheme.primary,
-                  ),
+                fontWeight: FontWeight.w600,
+                color: AppTheme.primary,
+              ),
             ),
             const SizedBox(height: 4),
             Text(
               label,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: AppTheme.primary.withValues(alpha: 0.7),
-                  ),
+                color: AppTheme.primary.withValues(alpha: 0.7),
+              ),
               textAlign: TextAlign.center,
             ),
           ],
@@ -430,8 +439,9 @@ class ScreentimeViewPage extends ConsumerWidget {
 
   String _getMostActiveHour(Map<String, int> usageData) {
     if (usageData.isEmpty) return '--';
-    final maxEntry =
-        usageData.entries.reduce((a, b) => a.value > b.value ? a : b);
+    final maxEntry = usageData.entries.reduce(
+      (a, b) => a.value > b.value ? a : b,
+    );
     final hour = int.parse(maxEntry.key);
     final timeString = '${hour.toString().padLeft(2, '0')}:00';
     return '$timeString\n${_formatDuration(maxEntry.value)}';
@@ -439,10 +449,9 @@ class ScreentimeViewPage extends ConsumerWidget {
 
   String _getFirstUsage(Map<String, int> usageData) {
     if (usageData.isEmpty) return '--';
-    final sortedEntries = usageData.entries
-        .where((entry) => entry.value > 0)
-        .toList()
-      ..sort((a, b) => int.parse(a.key).compareTo(int.parse(b.key)));
+    final sortedEntries =
+        usageData.entries.where((entry) => entry.value > 0).toList()
+          ..sort((a, b) => int.parse(a.key).compareTo(int.parse(b.key)));
 
     if (sortedEntries.isEmpty) return '--';
 

--- a/lib/screens/Usage.dart
+++ b/lib/screens/Usage.dart
@@ -1,48 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:screen_time/providers/usage_provider.dart';
 import 'package:screen_time/services/foreground_service.dart';
 import 'package:screen_time/theme/app_theme.dart';
+import 'package:screen_time/utils/platform_utils.dart';
 import 'package:screen_time/widgets/grant_permission_view.dart';
 import 'package:go_router/go_router.dart';
-import 'dart:io';
 
 class UsagePage extends HookConsumerWidget {
   const UsagePage({super.key});
 
-  void _startForeGroundService() async {
+  Future<void> _startForegroundService() async {
     try {
       if (await ForegroundService.instance.isRunningService) {
         return;
       }
 
-      ForegroundService.instance.start();
-    } catch (e) {}
+      await ForegroundService.instance.start();
+    } catch (e) {
+      debugPrint('Failed to start foreground service: $e');
+    }
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!Platform.isAndroid) {
+    if (!PlatformUtils.isAndroid) {
       useEffect(() {
         Future.microtask(() {
+          if (!context.mounted) {
+            return;
+          }
           context.go('/');
         });
         return null;
       }, []);
 
-      return const Scaffold(
-        body: Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
 
     final usageState = ref.watch(usageProvider);
 
     useEffect(() {
-      _startForeGroundService();
+      _startForegroundService();
       final observer = _UsageLifecycleObserver(ref);
       WidgetsBinding.instance.addObserver(observer);
       return () {
@@ -53,17 +53,13 @@ class UsagePage extends HookConsumerWidget {
     useEffect(() {
       if (usageState.hasPermission) {
         Future.microtask(() {
-          if (ModalRoute.of(context)?.settings.name == '/usage' || true) {
-            if (Navigator.canPop(context)) {
-              Navigator.popUntil(context, (route) => route.isFirst);
-            }
-            try {
-              // ignore: invalid_use_of_visible_for_testing_member
-              // ignore: invalid_use_of_protected_member
-              // ignore: unnecessary_cast
-              (GoRouter.of(context) as dynamic).go('/');
-            } catch (_) {}
+          if (!context.mounted) {
+            return;
           }
+          if (Navigator.canPop(context)) {
+            Navigator.popUntil(context, (route) => route.isFirst);
+          }
+          context.go('/');
         });
       }
       return null;

--- a/lib/services/foreground_service.dart
+++ b/lib/services/foreground_service.dart
@@ -1,11 +1,6 @@
-import 'dart:developer';
-import 'dart:io';
-
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
-import 'package:permission_handler/permission_handler.dart';
-import 'package:screen_time/providers/usage_provider.dart';
 import 'package:screen_time/services/screentime_service.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:screen_time/utils/platform_utils.dart';
 
 class ForegroundService {
   ForegroundService._();
@@ -22,7 +17,7 @@ class ForegroundService {
       await FlutterForegroundTask.requestNotificationPermission();
     }
 
-    if (Platform.isAndroid) {
+    if (PlatformUtils.isAndroid) {
       // Android 12+, there are restrictions on starting a foreground service.
       //
       // To restart the service on device reboot or unexpected problem, you need to allow below permission.
@@ -73,14 +68,12 @@ class ForegroundService {
 
     final ServiceRequestResult result =
         await FlutterForegroundTask.startService(
-      serviceTypes: [
-        ForegroundServiceTypes.dataSync,
-      ],
-      serviceId: 500,
-      notificationTitle: 'Screentime Service is running',
-      notificationText: '',
-      callback: startScreentimeService,
-    );
+          serviceTypes: [ForegroundServiceTypes.dataSync],
+          serviceId: 500,
+          notificationTitle: 'Screentime Service is running',
+          notificationText: '',
+          callback: startScreentimeService,
+        );
 
     if (result is ServiceRequestFailure) {
       throw result.error;

--- a/lib/services/screentime_service.dart
+++ b/lib/services/screentime_service.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:developer' as dev;
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:screen_time/providers/usage_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/foundation.dart';
+
+class PlatformUtils {
+  static bool get isAndroid =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  static bool get isIOS =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+}

--- a/lib/widgets/grant_permission_view.dart
+++ b/lib/widgets/grant_permission_view.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/usage_provider.dart';
 import 'package:screen_time/theme/app_theme.dart';
-import 'dart:io';
+import 'package:screen_time/utils/platform_utils.dart';
 
 class GrantPermissionView extends ConsumerWidget {
   const GrantPermissionView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!Platform.isAndroid) {
+    if (!PlatformUtils.isAndroid) {
       return Center(
         child: Padding(
           padding: AppTheme.elementPadding,
@@ -75,8 +75,11 @@ class GrantPermissionView extends ConsumerWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Icon(Icons.privacy_tip_rounded,
-                  size: 56, color: AppTheme.primary),
+              Icon(
+                Icons.privacy_tip_rounded,
+                size: 56,
+                color: AppTheme.primary,
+              ),
               AppTheme.spacer,
               Text(
                 'Ge åtkomst till användarspårning',
@@ -96,10 +99,14 @@ class GrantPermissionView extends ConsumerWidget {
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppTheme.accent,
                   foregroundColor: Colors.white,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 14,
+                  ),
                   textStyle: const TextStyle(
-                      fontWeight: FontWeight.w600, fontSize: 16),
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  ),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:screen_time/providers/user_provider.dart';
+import 'package:screen_time/utils/platform_utils.dart';
 import '../providers/usage_provider.dart';
-import 'dart:io';
 
 class UploadButton extends ConsumerWidget {
   const UploadButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!Platform.isAndroid) {
+    if (!PlatformUtils.isAndroid) {
       return const SizedBox.shrink();
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -175,7 +175,7 @@ packages:
     source: hosted
     version: "2.0.30"
   flutter_riverpod:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_riverpod
       sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
+  flutter_riverpod: ^2.6.1
   hooks_riverpod: ^2.6.1
   shared_preferences: ^2.5.3
   http: ^0.13.5

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
   permission_handler_windows
 )
 


### PR DESCRIPTION
## Summary
- register the app lifecycle observer once with cleanup so resume handling does not multiply uploads/validation
- make screen-time local persistence use the freshly fetched data and wait for persisted upload throttling state
- replace direct dart:io platform checks with a shared Flutter platform helper, keeping app code cleaner across targets
- make Flutter Riverpod a direct dependency and keep generated plugin registration aligned with resolved dependencies

## Validation
- flutter test
- dart analyze (passes with existing info-level lint output)